### PR TITLE
Fixed. `docker build` is failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --update --no-cache add bash git \
 RUN wget https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest -O /usr/local/bin/ecs-cli \
  && chmod 755 /usr/local/bin/ecs-cli \
  && apk --update --no-cache add --virtual .build-deps gnupg curl \
- && curl https://raw.githubusercontent.com/aws/amazon-ecs-cli/master/amazon-ecs-public-key.gpg | gpg --import \
+ && curl https://raw.githubusercontent.com/aws/amazon-ecs-cli/mainline/amazon-ecs-public-key.gpg | gpg --import \
  && curl -o ecs-cli.asc https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest.asc \
  && gpg --verify ecs-cli.asc /usr/local/bin/ecs-cli \
  && rm ecs-cli.asc \


### PR DESCRIPTION
```
gpg: no valid OpenPGP data found.
```

https://app.circleci.com/pipelines/github/sue445/dockerfile-awscli-all/960/workflows/693cd521-467d-4c08-944e-aa8e13c99a0e/jobs/801