### PR TITLE
Use gpg --recv instead of curl from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --update --no-cache add bash git \
 RUN wget https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest -O /usr/local/bin/ecs-cli \
  && chmod 755 /usr/local/bin/ecs-cli \
  && apk --update --no-cache add --virtual .build-deps gnupg curl \
- && curl https://raw.githubusercontent.com/aws/amazon-ecs-cli/mainline/amazon-ecs-public-key.gpg | gpg --import \
+ && gpg --keyserver hkp://keys.gnupg.net --recv BCE9D9A42D51784F \
  && curl -o ecs-cli.asc https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest.asc \
  && gpg --verify ecs-cli.asc /usr/local/bin/ecs-cli \
  && rm ecs-cli.asc \


### PR DESCRIPTION
Now, `gpg --keyserver hkp://keys.gnupg.net --recv BCE9D9A42D51784F` is recommended. (curl from github is retired?)
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html