### PR TITLE
Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.7-alpine
 ENV AWSCLI_VERSION 1.26.4
 
 RUN apk --update --no-cache add bash git \
- && apk --update --no-cache add --virtual .build-deps gcc musl-dev \
+ && apk --update --no-cache add --virtual .build-deps gcc musl-dev libffi-dev \
  && pip install --no-cache-dir awscli==$AWSCLI_VERSION aws-sam-cli \
  && apk del .build-deps --purge
 


### PR DESCRIPTION
ref. https://github.com/sue445/dockerfile-awscli-all/actions/runs/3353102774/jobs/5555685661

```
DTHREAD_STACK_SIZE=0x100000 -fPIC -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/local/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.7/c/_cffi_backend.o
      c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
         15 | #include <ffi.h>
            |          ^~~~~~~
      compilation terminated.
      error: command 'gcc' failed with exit status 1
      [end of output]
```