### PR TITLE
awscli 1.32.0+ requires python 3.8+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine AS ecs-cli-downloader
 RUN wget https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest -O /usr/local/bin/ecs-cli \
  && chmod 755 /usr/local/bin/ecs-cli
 
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 ENV AWSCLI_VERSION 1.32.2
 


### PR DESCRIPTION
```
12.01 ERROR: Ignored the following versions that require a different python version: 1.32.0 Requires-Python >= 3.8; 1.32.1 Requires-Python >= 3.8; 1.32.2 Requires-Python >= 3.8; 1.32.3 Requires-Python >= 3.8
```

Close #29