### PR TITLE
Upgrade to python 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine AS ecs-cli-downloader
 RUN wget https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest -O /usr/local/bin/ecs-cli \
  && chmod 755 /usr/local/bin/ecs-cli
 
-FROM python:3.9-alpine
+FROM python:3.14-alpine
 
 ENV AWSCLI_VERSION 1.45.0
 


### PR DESCRIPTION
Requires python 3.10 since awscli 1.45.0

ref. https://github.com/aws/aws-cli/commit/b840ed5f99b7b17010eb9f4e6bb899ad486d6244

Close #39